### PR TITLE
psr/log should not be in require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
     "require": {
         "php": ">=5.5",
         "guzzlehttp/psr7": "^1.3.1",
-        "guzzlehttp/promises": "^1.0"
+        "guzzlehttp/promises": "^1.0",
+        "psr/log": "^1.0"
     },
     "require-dev": {
         "ext-curl": "*",
-        "phpunit/phpunit": "^4.0",
-        "psr/log": "^1.0"
+        "phpunit/phpunit": "^4.0"
     },
     "autoload": {
         "files": ["src/functions_include.php"],


### PR DESCRIPTION
Since you have a middleware in Middleware class taht is using the LoggerInterface and this class is bundled with the package and it is not just for testing then I believe that psr/log should not be in require-dev.